### PR TITLE
Add read mode for Tron XRP wallet

### DIFF
--- a/charts/shkeeper/templates/deployments/shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/shkeeper.yaml
@@ -45,6 +45,8 @@ spec:
             value: {{ if .Values.doge.enabled }}enabled{{ else }}disabled{{ end }}
           - name: TRX_WALLET
             value: {{ if .Values.trx.enabled }}enabled{{ else }}disabled{{ end }}
+          - name: TRX_READ_MODE
+            value: {{ if .Values.trx.read_mode }}enabled{{ else }}disabled{{ end }}
           - name: USDT_WALLET
             value: {{ if .Values.usdt.enabled }}enabled{{ else }}disabled{{ end }}
           - name: USDC_WALLET

--- a/charts/shkeeper/templates/deployments/shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/shkeeper.yaml
@@ -47,6 +47,8 @@ spec:
             value: {{ if .Values.trx.enabled }}enabled{{ else }}disabled{{ end }}
           - name: TRX_READ_MODE
             value: {{ if .Values.trx.read_mode }}enabled{{ else }}disabled{{ end }}
+          - name: XRP_READ_MODE
+            value: {{ if .Values.xrp.read_mode }}enabled{{ else }}disabled{{ end }}
           - name: USDT_WALLET
             value: {{ if .Values.usdt.enabled }}enabled{{ else }}disabled{{ end }}
           - name: USDC_WALLET

--- a/charts/shkeeper/templates/deployments/tron-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/tron-shkeeper.yaml
@@ -60,6 +60,8 @@ spec:
             value: "shkeeper:5000"
           - name: FULLNODE_URL
             value: {{ .Values.tron_fullnode.url }}
+          - name: READ_MODE
+            value: {{ if .Values.trx.read_mode }}enabled{{ else }}disabled{{ end }}
           {{- if .Values.tron_shkeeper.multiserver_config_json }}
           - name: MULTISERVER_CONFIG_JSON
             value: {{ .Values.tron_shkeeper.multiserver_config_json | toJson | quote }}

--- a/charts/shkeeper/templates/deployments/xrp-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/xrp-shkeeper.yaml
@@ -61,6 +61,8 @@ spec:
           {{- end }}
           - name: FULLNODE_URL
             value: {{ .Values.xrp_fullnode.url }}
+          - name: READ_MODE
+            value: {{ if .Values.xrp.read_mode }}enabled{{ else }}disabled{{ end }}
           {{- range $name, $value := .Values.xrp_shkeeper.extraEnv }}
           - name: {{ $name | quote }}
             value: {{ $value | quote }}

--- a/docker-compose/shkeeper/templates/shkeeper.yaml
+++ b/docker-compose/shkeeper/templates/shkeeper.yaml
@@ -28,6 +28,7 @@ services:
       BNB_USDT_WALLET: "{{- if .Values.bnb_usdt.enabled }}enabled{{ else }}disabled{{- end }}"
       BNB_USDC_WALLET: "{{- if .Values.bnb_usdc.enabled }}enabled{{ else }}disabled{{- end }}"
       XRP_WALLET: "{{- if .Values.xrp.enabled }}enabled{{ else }}disabled{{- end }}"
+      XRP_READ_MODE: "{{- if .Values.xrp.read_mode }}enabled{{ else }}disabled{{- end }}"
       MATIC_WALLET: "{{- if .Values.matic.enabled }}enabled{{ else }}disabled{{- end }}"
       POLYGON_USDT_WALLET: "{{- if .Values.polygon_usdt.enabled }}enabled{{ else }}disabled{{- end }}"
       POLYGON_USDC_WALLET: "{{- if .Values.polygon_usdc.enabled }}enabled{{ else }}disabled{{- end }}"
@@ -552,6 +553,7 @@ services:
       BTC_PASSWORD: "test"
       SHKEEPER_BACKEND_KEY: "key"
       SHKEEPER_HOST: "shkeeper:5000"
+      READ_MODE: {{ if .Values.trx.read_mode }}enabled{{ else }}disabled{{ end }}
       FULLNODE_URL: {{ .Values.tron_fullnode.url }}
       {{- if .Values.tron_shkeeper.multiserver_config_json }}
       MULTISERVER_CONFIG_JSON: {{ .Values.tron_shkeeper.multiserver_config_json | toJson | quote }}
@@ -621,6 +623,7 @@ services:
       {{- else }}
       XRP_NETWORK: "testnet"
       {{- end }}
+      READ_MODE: {{ if .Values.xrp.read_mode }}enabled{{ else }}disabled{{ end }}
       FULLNODE_URL: {{ .Values.xrp_fullnode.url }}
       {{- range $name, $value := .Values.xrp_shkeeper.extraEnv }}
       {{ $name }}: {{ $value | quote }}

--- a/docker-compose/shkeeper/templates/shkeeper.yaml
+++ b/docker-compose/shkeeper/templates/shkeeper.yaml
@@ -16,6 +16,7 @@ services:
       LTC_WALLET: "{{- if .Values.ltc.enabled }}enabled{{ else }}disabled{{- end }}"
       DOGE_WALLET: "{{- if .Values.doge.enabled }}enabled{{ else }}disabled{{- end }}"
       TRX_WALLET: "{{- if .Values.trx.enabled }}enabled{{ else }}disabled{{- end }}"
+      TRX_READ_MODE: "{{- if .Values.trx.read_mode }}enabled{{ else }}disabled{{- end }}"
       USDT_WALLET: "{{- if .Values.usdt.enabled }}enabled{{ else }}disabled{{- end }}"
       USDC_WALLET: "{{- if .Values.usdc.enabled }}enabled{{ else }}disabled{{- end }}"
       ETH_WALLET: "{{- if .Values.eth.enabled }}enabled{{ else }}disabled{{- end }}"


### PR DESCRIPTION
This PR enhances the Helm chart by adding support for using a crypto wallet in read-only mode.

Specifically, it introduces the TRX_READ_MODE: 'enabled' configuration option.