### PR TITLE
feat(evm): deploy ETH-like via unified ethereum_like_coin image

### DIFF
--- a/charts/shkeeper/templates/deployments/arbitrum-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/arbitrum-shkeeper.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
 
       - name: app
-        image: {{ .Values.arbitrum_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command:
         - gunicorn
         - --access-logfile=-
@@ -38,6 +38,8 @@ spec:
         - containerPort: 6000
           name: http
         env:
+          - name: WALLET
+            value: "ARBETH"
           - name: ARB_USERNAME
             valueFrom:
               secretKeyRef:
@@ -71,9 +73,11 @@ spec:
           {{- end }}
 
       - name: tasks
-        image: {{ .Values.arbitrum_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command: ["celery", "-A", "celery_worker.celery", "worker", "--loglevel=info", "-B"]
         env:
+          - name: WALLET
+            value: "ARBETH"
           - name: ARB_USERNAME
             valueFrom:
               secretKeyRef:

--- a/charts/shkeeper/templates/deployments/avalanche-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/avalanche-shkeeper.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
 
       - name: app
-        image: {{ .Values.avalanche_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command:
         - gunicorn
         - --access-logfile=-
@@ -38,6 +38,8 @@ spec:
         - containerPort: 6000
           name: http
         env:
+          - name: WALLET
+            value: "AVAX"
           - name: AVALANCHE_USERNAME
             valueFrom:
               secretKeyRef:
@@ -67,9 +69,11 @@ spec:
           {{- end }}
 
       - name: tasks
-        image: {{ .Values.avalanche_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command: ["celery", "-A", "celery_worker.celery", "worker", "--loglevel=info", "-B"]
         env:
+          - name: WALLET
+            value: "AVAX"
           - name: AVALANCHE_USERNAME
             valueFrom:
               secretKeyRef:

--- a/charts/shkeeper/templates/deployments/bnb-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/bnb-shkeeper.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
 
       - name: app
-        image: {{ .Values.bnb_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command:
         - gunicorn
         - --access-logfile=-
@@ -38,6 +38,8 @@ spec:
         - containerPort: 6000
           name: http
         env:
+          - name: WALLET
+            value: "BNB"
           - name: BNB_USERNAME
             valueFrom:
               secretKeyRef:
@@ -61,15 +63,21 @@ spec:
           {{- end }}
           - name: FULLNODE_URL
             value: {{ .Values.bnb_fullnode.url }}
+          {{- if .Values.bnb_shkeeper.external_drain_config }}
+          - name: EXTERNAL_DRAIN_CONFIG
+            value: {{ .Values.bnb_shkeeper.external_drain_config | toJson | quote }}
+          {{- end }}
           {{- range $name, $value := .Values.bnb_shkeeper.extraEnv }}
           - name: {{ $name | quote }}
             value: {{ $value | quote }}
           {{- end }}
 
       - name: tasks
-        image: {{ .Values.bnb_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command: ["celery", "-A", "celery_worker.celery", "worker", "--loglevel=info", "-B"]
         env:
+          - name: WALLET
+            value: "BNB"
           - name: BNB_USERNAME
             valueFrom:
               secretKeyRef:
@@ -93,6 +101,10 @@ spec:
           {{- end }}
           - name: FULLNODE_URL
             value: {{ .Values.bnb_fullnode.url }}
+          {{- if .Values.bnb_shkeeper.external_drain_config }}
+          - name: EXTERNAL_DRAIN_CONFIG
+            value: {{ .Values.bnb_shkeeper.external_drain_config | toJson | quote }}
+          {{- end }}
           - name: C_FORCE_ROOT
             value: "1"
           {{- range $name, $value := .Values.bnb_shkeeper.extraEnv }}

--- a/charts/shkeeper/templates/deployments/ethereum-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/ethereum-shkeeper.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
 
       - name: app
-        image: {{ .Values.ethereum_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command:
         - gunicorn
         - --access-logfile=-
@@ -38,6 +38,8 @@ spec:
         - containerPort: 6000
           name: http
         env:
+          - name: WALLET
+            value: "ETH"
           - name: ETH_USERNAME
             valueFrom:
               secretKeyRef:
@@ -71,9 +73,11 @@ spec:
           {{- end }}
 
       - name: tasks
-        image: {{ .Values.ethereum_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command: ["celery", "-A", "celery_worker.celery", "worker", "--loglevel=info", "-B"]
         env:
+          - name: WALLET
+            value: "ETH"
           - name: ETH_USERNAME
             valueFrom:
               secretKeyRef:

--- a/charts/shkeeper/templates/deployments/optimism-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/optimism-shkeeper.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
 
       - name: app
-        image: {{ .Values.optimism_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command:
         - gunicorn
         - --access-logfile=-
@@ -38,6 +38,8 @@ spec:
         - containerPort: 6000
           name: http
         env:
+          - name: WALLET
+            value: "OPETH"
           - name: OP_USERNAME
             valueFrom:
               secretKeyRef:
@@ -71,9 +73,11 @@ spec:
           {{- end }}
 
       - name: tasks
-        image: {{ .Values.optimism_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command: ["celery", "-A", "celery_worker.celery", "worker", "--loglevel=info", "-B"]
         env:
+          - name: WALLET
+            value: "OPETH"
           - name: OP_USERNAME
             valueFrom:
               secretKeyRef:

--- a/charts/shkeeper/templates/deployments/polygon-shkeeper.yaml
+++ b/charts/shkeeper/templates/deployments/polygon-shkeeper.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
 
       - name: app
-        image: {{ .Values.polygon_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command:
         - gunicorn
         - --access-logfile=-
@@ -38,6 +38,8 @@ spec:
         - containerPort: 6000
           name: http
         env:
+          - name: WALLET
+            value: "MATIC"
           - name: POLYGON_USERNAME
             valueFrom:
               secretKeyRef:
@@ -61,15 +63,21 @@ spec:
           {{- end }}
           - name: FULLNODE_URL
             value: {{ .Values.polygon_fullnode.url }}
+          {{- if .Values.polygon_shkeeper.external_drain_config }}
+          - name: EXTERNAL_DRAIN_CONFIG
+            value: {{ .Values.polygon_shkeeper.external_drain_config | toJson | quote }}
+          {{- end }}
           {{- range $name, $value := .Values.polygon_shkeeper.extraEnv }}
           - name: {{ $name | quote }}
             value: {{ $value | quote }}
           {{- end }}
 
       - name: tasks
-        image: {{ .Values.polygon_shkeeper.image }}
+        image: {{ .Values.ethereum_like_shkeeper.image }}
         command: ["celery", "-A", "celery_worker.celery", "worker", "--loglevel=info", "-B"]
         env:
+          - name: WALLET
+            value: "MATIC"
           - name: POLYGON_USERNAME
             valueFrom:
               secretKeyRef:
@@ -93,6 +101,10 @@ spec:
           {{- end }}
           - name: FULLNODE_URL
             value: {{ .Values.polygon_fullnode.url }}
+          {{- if .Values.polygon_shkeeper.external_drain_config }}
+          - name: EXTERNAL_DRAIN_CONFIG
+            value: {{ .Values.polygon_shkeeper.external_drain_config | toJson | quote }}
+          {{- end }}
           - name: C_FORCE_ROOT
             value: "1"
           {{- range $name, $value := .Values.polygon_shkeeper.extraEnv }}

--- a/charts/shkeeper/values.yaml
+++ b/charts/shkeeper/values.yaml
@@ -104,6 +104,13 @@ usdc:
   enabled: false
 
 #
+# EVM (ethereum_like_coin): shared image for ETH/BNB/MATIC/AVAX/ARB/OP
+#
+
+ethereum_like_shkeeper:
+  image: &ethereum_like_image vsyshost/ethereum_like_coin:1.0.1
+
+#
 # Ethereum
 #
 
@@ -115,7 +122,7 @@ eth_fullnode:
   tolerations: []
 
 ethereum_shkeeper:
-  image: vsyshost/ethereum-shkeeper:1.2.4
+  image: *ethereum_like_image
 
 eth:
   enabled: false
@@ -160,7 +167,7 @@ bnb_fullnode:
   tolerations: []
 
 bnb_shkeeper:
-  image: vsyshost/bnb-shkeeper:1.1.9
+  image: *ethereum_like_image
 
 bnb:
   enabled: false
@@ -198,7 +205,7 @@ polygon_fullnode:
   tolerations: []
 
 polygon_shkeeper:
-  image: vsyshost/polygon-shkeeper:1.0.4
+  image: *ethereum_like_image
 
 matic:
   enabled: false
@@ -219,7 +226,7 @@ avalanche_fullnode:
   tolerations: []
 
 avalanche_shkeeper:
-  image: vsyshost/avalanche-shkeeper:1.0.2
+  image: *ethereum_like_image
 
 avax:
   enabled: false
@@ -294,7 +301,7 @@ arb_fullnode:
   tolerations: []
 
 arbitrum_shkeeper:
-  image: vsyshost/arbitrum-shkeeper:0.0.1
+  image: *ethereum_like_image
 
 arbeth:
   enabled: false
@@ -318,7 +325,7 @@ optimism_fullnode:
   tolerations: []
 
 optimism_shkeeper:
-  image: vsyshost/optimism-shkeeper:0.0.2
+  image: *ethereum_like_image
 
 opeth:
   enabled: false

--- a/docker-compose/shkeeper/templates/shkeeper.yaml
+++ b/docker-compose/shkeeper/templates/shkeeper.yaml
@@ -407,9 +407,10 @@ services:
 {{- /*       Ethereum shkeeper       */}}
 {{- if or .Values.eth.enabled .Values.eth_usdt.enabled .Values.eth_usdc.enabled .Values.eth_pyusd.enabled .Values.eth_dai.enabled}}
   ethereum-shkeeper:
-    image: {{ .Values.ethereum_shkeeper.image }}
+    image: {{ .Values.ethereum_like_shkeeper.image }}
     container_name: ethereum-shkeeper
     environment:
+      WALLET: ETH
       REDIS_HOST: redis
       ETH_USERNAME: "test"
       ETH_PASSWORD: "test"
@@ -435,9 +436,10 @@ services:
       --bind=0.0.0.0:6000
       run:server"
   ethereum-tasks:
-    image: {{ .Values.ethereum_shkeeper.image }}
+    image: {{ .Values.ethereum_like_shkeeper.image }}
     container_name: ethereum-tasks
     environment:
+      WALLET: ETH
       REDIS_HOST: redis
       ETH_USERNAME: "test"
       ETH_PASSWORD: "test"

--- a/docker-compose/shkeeper/values.yaml
+++ b/docker-compose/shkeeper/values.yaml
@@ -75,8 +75,11 @@ eth_fullnode:
   nodeSelector: {}
   tolerations: []
 
+ethereum_like_shkeeper:
+  image: &ethereum_like_image vsyshost/ethereum_like_coin:1.0.1
+
 ethereum_shkeeper:
-  image: vsyshost/ethereum-shkeeper:1.1.7
+  image: *ethereum_like_image
 
 eth:
   enabled: false
@@ -121,7 +124,7 @@ bnb_fullnode:
   tolerations: []
 
 bnb_shkeeper:
-  image: vsyshost/bnb-shkeeper:1.1.5
+  image: *ethereum_like_image
 
 bnb:
   enabled: false
@@ -159,7 +162,7 @@ polygon_fullnode:
   tolerations: []
 
 polygon_shkeeper:
-  image: vsyshost/polygon-shkeeper:1.0.3
+  image: *ethereum_like_image
 
 matic:
   enabled: false
@@ -180,7 +183,7 @@ avalanche_fullnode:
   tolerations: []
 
 avalanche_shkeeper:
-  image: vsyshost/avalanche-shkeeper:1.0.0
+  image: *ethereum_like_image
 
 avax:
   enabled: false


### PR DESCRIPTION
- Add evm_like_shkeeper.image in values.yaml as the shared EVM backend image
- Set WALLET=ETH on ethereum-shkeeper deployment (app + tasks)
- Set WALLET=ARBETH on arbitrum-shkeeper deployment (app + tasks)
- Set WALLET=OPETH on optimism-shkeeper deployment (app + tasks)
- Set WALLET=AVAX on avalcnche-shkeeper deployment (app + tasks)
- Set WALLET=BNB on bnb-shkeeper deployment (app + tasks)
- Set WALLET=MATIC on polygon-shkeeper deployment (app + tasks)